### PR TITLE
type(AMap.MoveAnimation): fix AMap.MoveAnimation of ControlType in AM…

### DIFF
--- a/packages/types/src/core.d.ts
+++ b/packages/types/src/core.d.ts
@@ -335,7 +335,8 @@ declare namespace AMap {
     'AMap.ToolBar' |
     'AMap.MapType' |
     'AMap.Walking' |
-    'AMap.Weather';
+    'AMap.Weather' |
+    'AMap.MoveAnimation';
   interface MapEvents {
     /**
      * 地图缩放级别更改后触发


### PR DESCRIPTION
在官方的[轨迹回放demo](https://lbs.amap.com/demo/jsapi-v2/example/marker/replaying-historical-running-data)中，需要加载插件`AMap.MoveAnimation`，但本库中的`ControlType`缺少该类型