### PR TITLE
fix(polygon): use `remove` instead of `removeLayer` on amap v2

### DIFF
--- a/packages/polygon/src/usePolygon.tsx
+++ b/packages/polygon/src/usePolygon.tsx
@@ -16,12 +16,13 @@ export const usePolygon = (props = {} as UsePolygon) => {
       setPolygon(instance);
       return () => {
         if (instance) {
-          if (AMap.v) {
-            map && map.remove(instance);
-          } else {
-            // 暂不使用这个 API，这个不兼容 v1.4.xx，改用 map.remove API
-            map && map.removeLayer(instance);
-          }
+          map && map.remove(instance);
+          // if (AMap.v) {
+          //   map && map.remove(instance);
+          // } else {
+          //   // 暂不使用这个 API，这个不兼容 v1.4.xx，改用 map.remove API
+          //   map && map.removeLayer(instance);
+          // }
           setPolygon(undefined);
         }
       };


### PR DESCRIPTION
我的用法是：

```tsx
const polygons = useMemo(()=>list.map(item=>(
 <Fragment key={item.randomKey}>
  <Polygon  visible={isValidPath(item.path)} path={item.path} />
  <Text text={item.text}/>
 </Fragment>
)), [list])
```

然后遇到问题：list数据刷新以后,Text能正常自动移除，但是Polygon没有自动移除。换成`remove`以后就能正常工作了。