### PR TITLE
fix(polygon): ignore error when map unmounted

### DIFF
--- a/packages/polygon/src/usePolygon.tsx
+++ b/packages/polygon/src/usePolygon.tsx
@@ -16,15 +16,17 @@ export const usePolygon = (props = {} as UsePolygon) => {
       setPolygon(instance);
       return () => {
         if (instance) {
-          map && map.remove(instance);
+          try {
+            map && map.remove(instance);
+          } catch (e) {}
           // if (AMap.v) {
           //   map && map.remove(instance);
           // } else {
           //   // 暂不使用这个 API，这个不兼容 v1.4.xx，改用 map.remove API
           //   map && map.removeLayer(instance);
           // }
-          setPolygon(undefined);
         }
+        setPolygon(undefined);
       };
     }
   }, [map]);


### PR DESCRIPTION
related #320 

改成 remove 以后又发现在  antd  的  modal 上使用时，关闭弹窗会报错。

复现：https://github.com/MashiroArchive/react-amap-bug-repoort

codesandbox：https://codesandbox.io/p/github/MashiroArchive/react-amap-bug-repoort/main

可能是 amap sdk 内调用了polygon instance 的内部 remove 方法（这个时候 instance 已经被销毁了），导致的报错：
<img width="1624" alt="image" src="https://github.com/uiwjs/react-amap/assets/16148054/f9372fd9-dbaf-41c7-8ba0-b0bec9e7e679">

我暂时想不到既能确保polygon 能正常移除，同时又不会报错的方法了，虽然不优雅但 try catch 能解决问题