### PR TITLE
fix: Map 子组件函数签名

### DIFF
--- a/packages/map/src/index.tsx
+++ b/packages/map/src/index.tsx
@@ -14,7 +14,7 @@ export interface MapProps extends AMap.MapEvents, AMap.MapOptions {
   className?: React.HTMLAttributes<HTMLDivElement>['className'];
   style?: React.HTMLAttributes<HTMLDivElement>['style'];
   container?: HTMLDivElement | null;
-  children?: JSX.Element & RenderProps['children'];
+  children?: JSX.Element | RenderProps['children'];
 }
 
 export const Provider: FC<PropsWithChildren<RenderProps>> = (props) => {


### PR DESCRIPTION
修复使用 map 子组件时类型提示错误
![image](https://github.com/uiwjs/react-amap/assets/26276464/0630d229-38fe-47f3-9b3d-dd318480d914)
