### PR TITLE
fix: 修复重新设置path后鼠标事件失效

### DIFF
--- a/packages/polygon/src/usePolygon.tsx
+++ b/packages/polygon/src/usePolygon.tsx
@@ -33,7 +33,11 @@ export const usePolygon = (props = {} as UsePolygon) => {
 
   useEffect(() => {
     if (polygon) {
-      polygon.setOptions(other);
+      const { path, ...rest } = other;
+      if (path) {
+        polygon.setPath(path);
+      }
+      polygon.setOptions(rest);
     }
   }, [polygon, other]);
 

--- a/packages/polyline/src/usePolyline.tsx
+++ b/packages/polyline/src/usePolyline.tsx
@@ -33,7 +33,11 @@ export function usePolyline(props = {} as UsePolyline) {
 
   useEffect(() => {
     if (polyline) {
-      polyline.setOptions(other);
+      const { path, ...rest } = other;
+      if (path) {
+        polyline.setPath(path);
+      }
+      polyline.setOptions(rest);
     }
   }, [polyline, other]);
 


### PR DESCRIPTION
这个bug是高德自己的问题，Polygon如果使用AMap.LngLat来描述则鼠标事件全部失效。
如果使用[number, number][] 来描述path，同样的代码，鼠标事件有效。
然后高德给的解决方案不是转number，是使用setPath。

<img width="516" alt="image" src="https://github.com/user-attachments/assets/a094689f-3a72-41c1-a961-330ea01171d5">

<img width="507" alt="image" src="https://github.com/user-attachments/assets/36a28d82-2444-43e2-ac4b-89532e6a159e">

我在没有修改代码的情况下本地启动，然后再多边形那里拖几下就会爆炸，不知道是不是就是这样的。
<img width="704" alt="image" src="https://github.com/user-attachments/assets/09d4a34a-adae-46c9-8a5c-8b6ad968e54c">


