### PR TITLE
perf(peerDependencies): React19兼容React18项目

### DIFF
--- a/packages/amap/package.json
+++ b/packages/amap/package.json
@@ -13,8 +13,8 @@
   "author": "Kenny Wong <wowohoo@qq.com>",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "files": [
     "dist",

--- a/packages/api-loader/package.json
+++ b/packages/api-loader/package.json
@@ -30,8 +30,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@amap/amap-jsapi-loader": "^1.0.1",

--- a/packages/auto-complete/package.json
+++ b/packages/auto-complete/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/bezier-curve/package.json
+++ b/packages/bezier-curve/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/circle-marker/package.json
+++ b/packages/circle-marker/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/circle/package.json
+++ b/packages/circle/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/control-bar-control/package.json
+++ b/packages/control-bar-control/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/ellipse/package.json
+++ b/packages/ellipse/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/geolocation/package.json
+++ b/packages/geolocation/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3"

--- a/packages/hawk-eye-control/package.json
+++ b/packages/hawk-eye-control/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/info-window/package.json
+++ b/packages/info-window/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/label-marker/package.json
+++ b/packages/label-marker/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/map-type-control/package.json
+++ b/packages/map-type-control/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -28,8 +28,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-types": "7.1.3",

--- a/packages/marker/package.json
+++ b/packages/marker/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/mass-marks/package.json
+++ b/packages/mass-marks/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/mouse-tool/package.json
+++ b/packages/mouse-tool/package.json
@@ -33,8 +33,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/poly-editor/package.json
+++ b/packages/poly-editor/package.json
@@ -34,8 +34,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/polygon-editor/package.json
+++ b/packages/polygon-editor/package.json
@@ -33,8 +33,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/polygon/package.json
+++ b/packages/polygon/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/polyline-editor/package.json
+++ b/packages/polyline-editor/package.json
@@ -33,8 +33,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/polyline/package.json
+++ b/packages/polyline/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/rectangle/package.json
+++ b/packages/rectangle/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/require-script/package.json
+++ b/packages/require-script/package.json
@@ -30,8 +30,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-types": "7.1.3"

--- a/packages/scale-control/package.json
+++ b/packages/scale-control/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/tile-layer/package.json
+++ b/packages/tile-layer/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/tool-bar-control/package.json
+++ b/packages/tool-bar-control/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -30,8 +30,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-types": "7.1.3"

--- a/packages/weather/package.json
+++ b/packages/weather/package.json
@@ -31,8 +31,8 @@
     "高德地图"
   ],
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@uiw/react-amap-map": "7.1.3",

--- a/website/package.json
+++ b/website/package.json
@@ -15,8 +15,8 @@
   "author": "Kenny Wong <wowohoo@qq.com>",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@babel/runtime": "^7.18.9",


### PR DESCRIPTION
粗略检查了下代码，未使用React18已标注弃用的API，因此可直接兼容至React19，同时该改动不影响已经在使用的用户