### PR TITLE
fix: update `ReGeocoderResult` type

### DIFF
--- a/packages/types/src/control.d.ts
+++ b/packages/types/src/control.d.ts
@@ -97,8 +97,6 @@ declare namespace AMap {
    */
   interface ReGeocoderResult {
     info: string
-    status: string
-    count: string
     geocode: {
       formatted_address: string
       country: string
@@ -123,40 +121,26 @@ declare namespace AMap {
    */
   interface ReverseGeocodeResult {
     info: string
-    infocode: string
-    status: string
     regeocode: {
-      formatted_address: string
+      formattedAddress: string
       addressComponent: {
-        city: any[]
-        province: string
         adcode: string
-        district: string
-        towncode: string
-        streetNumber: {
-          number: string
-          location: string
-          direction: string
-          distance: string
-          street: string
-        }
-        country: string
-        township: string
-        businessAreas: {
-          location: string
-          name: string
-          id: string
-        }[]
-        building: {
-          name: any[]
-          type: any[]
-        }
-        neighborhood: {
-          name: any[]
-          type: any[]
-        }
+        building: string
+        buildingType: string
+        businessAreas: Array<BusinessArea>
+        city: string
         citycode: string
+        district: string
+        neighborhood: string
+        neighborhoodType: string
+        province: string
+        street: string
+        streetNumber: string
+        township: string
       }
+      crosses: Array<any>
+      pois: Array<any>
+      roads: Array<any>
     }
   }
   


### PR DESCRIPTION
Sorry for #387, I mistakenly converted the response of gaode restapi directly into the ts type.

Now it is updated to the correct api return result type.

![image](https://github.com/user-attachments/assets/d530e02e-74e7-4f8b-a2b4-0f8b0f532715)
