### PR TITLE
fix(polygon-editor): fixup polygonEditor hide issue

### DIFF
--- a/packages/polygon-editor/src/index.tsx
+++ b/packages/polygon-editor/src/index.tsx
@@ -38,6 +38,8 @@ export const PolygonEditor = forwardRef<PolygonEditorProps, PolygonEditorProps>(
     } else if (!visiable && active && polygon) {
       polyEditor.close();
       props.onEnd && props.onEnd({ target: polygon });
+    } else if (!visiable && !active && polygon) {
+      polyEditor.close();
     }
   }, [active, visiable, polygon]);
 


### PR DESCRIPTION


原有设计思路依赖 visiable 的状态，此状态在点击 editor 的点直到所有点消失时变为 false，即 onHide 触发的时候产生，此后 active 不再能够控制 editor 的 close，因此会出现如下情况：

<img width="464" height="293" alt="image" src="https://github.com/user-attachments/assets/21f2a424-553f-44d4-be24-d8ad30e1efed" />

产生的原因：没有通过地图交互移除点和线，而是直接控制 Polygon 来清除多边形，即先触发了 onHide，但假如此时 active 状态没有及时更新，close 就没有触发，之后 active 控制失效